### PR TITLE
Day 1 scan iterator

### DIFF
--- a/day1/Cargo.toml
+++ b/day1/Cargo.toml
@@ -6,3 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[dev-dependencies]
+criterion = { version = "0.3", features = ["html_reports"] }
+
+[[bench]]
+name = "bench"
+harness = false

--- a/day1/benches/bench.rs
+++ b/day1/benches/bench.rs
@@ -1,0 +1,10 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let input = include_str!("../input.txt");
+    c.bench_function("part1", |b| b.iter(|| day1::part1(black_box(input))));
+    c.bench_function("part2", |b| b.iter(|| day1::part2(black_box(input))));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/day1/src/lib.rs
+++ b/day1/src/lib.rs
@@ -1,0 +1,78 @@
+use std::str::Chars;
+
+struct FloorIter<'a> {
+    floor: i32,
+    instructions: Chars<'a>,
+}
+
+impl<'a> FloorIter<'a> {
+    fn new(s: &'a str) -> Self {
+        FloorIter {
+            floor: 0,
+            instructions: s.chars(),
+        }
+    }
+}
+
+impl Iterator for FloorIter<'_> {
+    type Item = i32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.instructions.next().map(|c| {
+            match c {
+                '(' => self.floor += 1,
+                ')' => self.floor -= 1,
+                _ => panic!("invalid input"),
+            }
+            self.floor
+        })
+    }
+}
+
+pub fn part1(input: &str) -> i32 {
+    FloorIter::new(input).last().unwrap()
+}
+
+pub fn part2(input: &str) -> usize {
+    FloorIter::new(input)
+        .zip(1..)
+        .find(|&(floor, _)| floor < 0)
+        .unwrap()
+        .1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_part_1_examples() {
+        assert_eq!(part1("(())"), 0);
+        assert_eq!(part1("()()"), 0);
+        assert_eq!(part1("((("), 3);
+        assert_eq!(part1("(()(()("), 3);
+        assert_eq!(part1("))((((("), 3);
+        assert_eq!(part1("())"), -1);
+        assert_eq!(part1("))("), -1);
+        assert_eq!(part1(")))"), -3);
+        assert_eq!(part1(")())())"), -3);
+    }
+
+    #[test]
+    fn test_part_2_examples() {
+        assert_eq!(part2(")"), 1);
+        assert_eq!(part2("()())"), 5);
+    }
+
+    #[test]
+    fn test_part_1_chris_input() {
+        let input = include_str!("../input.txt");
+        assert_eq!(part1(input), 280);
+    }
+
+    #[test]
+    fn test_part_2_chris_input() {
+        let input = include_str!("../input.txt");
+        assert_eq!(part2(input), 1797);
+    }
+}

--- a/day1/src/lib.rs
+++ b/day1/src/lib.rs
@@ -1,40 +1,32 @@
-use std::str::Chars;
+/// Santa starts on floor 0.
+const INITIAL_FLOOR: i32 = 0;
 
-struct FloorIter<'a> {
-    floor: i32,
-    instructions: Chars<'a>,
-}
-
-impl<'a> FloorIter<'a> {
-    fn new(s: &'a str) -> Self {
-        FloorIter {
-            floor: 0,
-            instructions: s.chars(),
-        }
+/// Updates the floor Santa would reach after following the passed `instruction`.
+/// Returns `Some(new_floor)` to be compatible with [`std::iter::Iterator::scan`].
+fn process_floor(current_floor: &mut i32, instruction: char) -> Option<i32> {
+    match instruction {
+        '(' => *current_floor += 1,
+        ')' => *current_floor -= 1,
+        _ => panic!("invalid input"),
     }
+    Some(*current_floor)
 }
 
-impl Iterator for FloorIter<'_> {
-    type Item = i32;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.instructions.next().map(|c| {
-            match c {
-                '(' => self.floor += 1,
-                ')' => self.floor -= 1,
-                _ => panic!("invalid input"),
-            }
-            self.floor
-        })
-    }
-}
-
+/// Returns the last floor Santa would be on after following all the instructions in `input`.
 pub fn part1(input: &str) -> i32 {
-    FloorIter::new(input).last().unwrap()
+    input
+        .chars()
+        .scan(INITIAL_FLOOR, process_floor)
+        .last()
+        .unwrap()
 }
 
+/// Returns the first day Santa be enter the basement on while following all the instructions in
+/// `input`.
 pub fn part2(input: &str) -> usize {
-    FloorIter::new(input)
+    input
+        .chars()
+        .scan(INITIAL_FLOOR, process_floor)
         .zip(1..)
         .find(|&(floor, _)| floor < 0)
         .unwrap()

--- a/day1/src/main.rs
+++ b/day1/src/main.rs
@@ -1,49 +1,7 @@
 use std::fs::read_to_string;
-use std::str::Chars;
 
 fn main() {
     let input = read_to_string("input.txt").unwrap();
-    println!("part1: {}", part1(&input));
-    println!("part2: {}", part2(&input));
-}
-
-struct FloorIter<'a> {
-    floor: i32,
-    instructions: Chars<'a>,
-}
-
-impl<'a> FloorIter<'a> {
-    fn new(s: &'a str) -> Self {
-        FloorIter {
-            floor: 0,
-            instructions: s.chars(),
-        }
-    }
-}
-
-impl Iterator for FloorIter<'_> {
-    type Item = i32;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.instructions.next().map(|c| {
-            match c {
-                '(' => self.floor += 1,
-                ')' => self.floor -= 1,
-                _ => panic!("invalid input"),
-            }
-            self.floor
-        })
-    }
-}
-
-fn part1(input: &str) -> i32 {
-    FloorIter::new(input).last().unwrap()
-}
-
-fn part2(input: &str) -> usize {
-    FloorIter::new(input)
-        .zip(1..)
-        .find(|&(floor, _)| floor < 0)
-        .unwrap()
-        .1
+    println!("part1: {}", day1::part1(&input));
+    println!("part2: {}", day1::part2(&input));
 }


### PR DESCRIPTION
**This PR**
Does two things:

- Moves the functional code for `day` to a `lib.rs` so
  we can add tests and refactor fearlessly!
- Uses the built in [`scan`][scan] method on iterators
  instead of using the custom iterator because I originally
  thought it'd be cleaner and shorter. I forgot that `scan`
  needed to return an `Option` so now there's a weird return
  at the bottom of `process_floor` so I'm not so sure anymore.
  You be the judge!
  
  [scan]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.scan