### PR TITLE
Optimize Day 1

### DIFF
--- a/day1/src/lib.rs
+++ b/day1/src/lib.rs
@@ -6,8 +6,7 @@ const INITIAL_FLOOR: i32 = 0;
 fn process_floor(current_floor: &mut i32, instruction: u8) -> Option<i32> {
     match instruction {
         b'(' => *current_floor += 1,
-        b')' => *current_floor -= 1,
-        _ => panic!("invalid input"),
+        _ => *current_floor -= 1,
     }
     Some(*current_floor)
 }

--- a/day1/src/lib.rs
+++ b/day1/src/lib.rs
@@ -9,6 +9,9 @@ fn process_floor(current_floor: &mut i32, instruction: u8) -> Option<i32> {
 }
 
 /// Returns the last floor Santa would be on after following all the instructions in `input`.
+///
+/// NOTE - I tried this with more-or-less `bytes().sum() * 2 - (81 * input.len())` and there was no
+/// appreciable performance change.
 pub fn part1(input: &str) -> i32 {
     input
         .bytes()

--- a/day1/src/lib.rs
+++ b/day1/src/lib.rs
@@ -4,10 +4,7 @@ const INITIAL_FLOOR: i32 = 0;
 /// Updates the floor Santa would reach after following the passed `instruction`.
 /// Returns `Some(new_floor)` to be compatible with [`std::iter::Iterator::scan`].
 fn process_floor(current_floor: &mut i32, instruction: u8) -> Option<i32> {
-    match instruction {
-        b'(' => *current_floor += 1,
-        _ => *current_floor -= 1,
-    }
+    *current_floor -= instruction as i32 * 2 - (b'(' as i32 + b')' as i32);
     Some(*current_floor)
 }
 

--- a/day1/src/lib.rs
+++ b/day1/src/lib.rs
@@ -3,10 +3,10 @@ const INITIAL_FLOOR: i32 = 0;
 
 /// Updates the floor Santa would reach after following the passed `instruction`.
 /// Returns `Some(new_floor)` to be compatible with [`std::iter::Iterator::scan`].
-fn process_floor(current_floor: &mut i32, instruction: char) -> Option<i32> {
+fn process_floor(current_floor: &mut i32, instruction: u8) -> Option<i32> {
     match instruction {
-        '(' => *current_floor += 1,
-        ')' => *current_floor -= 1,
+        b'(' => *current_floor += 1,
+        b')' => *current_floor -= 1,
         _ => panic!("invalid input"),
     }
     Some(*current_floor)
@@ -15,7 +15,7 @@ fn process_floor(current_floor: &mut i32, instruction: char) -> Option<i32> {
 /// Returns the last floor Santa would be on after following all the instructions in `input`.
 pub fn part1(input: &str) -> i32 {
     input
-        .chars()
+        .bytes()
         .scan(INITIAL_FLOOR, process_floor)
         .last()
         .unwrap()
@@ -25,7 +25,7 @@ pub fn part1(input: &str) -> i32 {
 /// `input`.
 pub fn part2(input: &str) -> usize {
     input
-        .chars()
+        .bytes()
         .scan(INITIAL_FLOOR, process_floor)
         .zip(1..)
         .find(|&(floor, _)| floor < 0)


### PR DESCRIPTION
**This PR**
Is broken up into 2 optimizations with 2 bookkeeping commits

### Commit 1

Iterate over `bytes` of the underlying string instead of `chars`.
I knew I was going to want this for the second optimization but
I wondered if it was going to improve performance on its own.
It doesn't change performance at all so I thought I'd split it out
so that the optimizations were more well contained.

### Commit 2

Remove unused `panic!` case. While this is definitely what you'd
want in production code it doesn't do anything for Advent of Code
and forces the compiler to emit branched code ([godbolt link][godbolt])
because there are three cases not trivially covered by straight math.
If we only have two cases, however, the compiler is able to do something
amazing.

**Fun Assembly Reading**
What I _thought_ would happen was that it'd have a branchless
conditional move. What it _actually_ did was compare the input byte to `40`
(which is `b'('`). It then sets the `al` register to 1 if they are equal and `0` if
they are not. `al` is the [last byte of the `eax` register][register]. It then doubles
the value in `eax` (which, from the last step is either 0 or 1 because of how we
set `al` to 0 or 1) so it is now either 0 or 2. Then it subtracts 1 to get to 1 or -1.

This resulted in a pretty reasonable speedup:

**Results**
```
part1                   time:   [1.3374 us 1.3447 us 1.3551 us]
                        change: [-92.914% -92.840% -92.771%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  5 (5.00%) high severe

part2                   time:   [1.0825 us 1.0928 us 1.1063 us]
                        change: [-59.226% -58.769% -58.253%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe
```

[godbolt]: https://godbolt.org/z/G3orq4sMc
[register]: https://www.cs.virginia.edu/~evans/cs216/guides/x86.html

### Commit 3

Attempts further optimization by manually writing branchless code.
Because we know the input isn't just `'('` or _something else_ - it's
specifically `'('` or `')'` we can further optimize with some math:

1. `b'(' == 40`
1. `b')' == 41`
1. double the byte value (giving `80` or `82` respectively)
1. subtract `81` (this is `b'(' + b')'`) giving `-1` or `1`
   respectively
1. subtract the result from the current floor giving "add/subtract 1"
   respectively

**Results**
```
part1                   time:   [887.71 ns 888.81 ns 890.01 ns]
                        change: [-34.070% -33.548% -33.024%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe

part2                   time:   [972.65 ns 976.20 ns 980.57 ns]
                        change: [-11.715% -10.738% -9.8842%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  5 (5.00%) high mild
  11 (11.00%) high severe
```

### Commit 4

I was hoping that updating `part1` to:

1. add up all the bytes
2. double the entire value
3. subtract `81` once for each byte of `input`
4. negate the whole thing

would be faster since we'd do fewer subtractions. This
turned out to not be the case because compilers are awesome.
I figured I'd forget this at some point and look back and try
and implement it again so I dropped a note to save Future Me
some time.